### PR TITLE
Add two possible correct answers to Titanic part 4

### DIFF
--- a/Data_Manipulation/scripts/step_4_titanic-correct.R
+++ b/Data_Manipulation/scripts/step_4_titanic-correct.R
@@ -27,7 +27,7 @@
 # When you are ready to move on, save the script and type submit(), or type 
 # reset() to reset the script to its original state.
 
-titanic_4 <- titanic %>% 
+titanic_4_a <- titanic %>% 
   select(Survived, Pclass, Age, Sex) %>%
   filter(!is.na(Age)) %>%
   mutate(agecat = cut(Age, breaks = c(0, 14.99, 50, 150), 
@@ -37,3 +37,15 @@ titanic_4 <- titanic %>%
   summarize(N = n(),
             survivors = sum(Survived == 1),
             perc_survived = 100 * survivors / N)
+
+titanic_4_b <- titanic %>% 
+  select(Survived, Pclass, Age, Sex) %>%
+  filter(!is.na(Age)) %>%
+  mutate(agecat = cut(Age, breaks = c(0, 14.99, 50, 150), 
+                      include.lowest = TRUE,
+                      labels = c("Under 15", "15 to 50", "Over 50"))) %>%
+  group_by(Pclass, agecat, Sex) %>%
+  summarize(N = n(),
+            survivors = sum(Survived == 1),
+            perc_survived = 100 * survivors / N) %>%
+  ungroup()


### PR DESCRIPTION
This has two datasets to check against, so that student answers won't be marked wrong based on whether or not they choose to `ungroup` the dataset before submitting their answer.
