### PR TITLE
factors on plants dataset

### DIFF
--- a/Looking_at_Data/initLesson.R
+++ b/Looking_at_Data/initLesson.R
@@ -10,7 +10,8 @@
                       'The_R_Programming_Environment', 'Looking_at_Data',
                       'plant-data.txt')
 # Read in data
-plants <- read.csv(.datapath, strip.white=TRUE, na.strings="")
+plants <- read.csv(.datapath, strip.white=TRUE, na.strings="",
+                   stringsAsFactors =True)
 
 # Remove annoying columns
 .cols2rm <- c('Accepted.Symbol', 'Synonym.Symbol')


### PR DESCRIPTION
In the current R by default, the columns are loaded as strings but the tutorial requires to load them as factors. I just fixed that.